### PR TITLE
Update dym.php

### DIFF
--- a/lib/dym.php
+++ b/lib/dym.php
@@ -29,7 +29,7 @@ DebMes('SAY FUNC: '.$ph);
         if (defined('SETTINGS_HOOK_BEFORE_SAY') && SETTINGS_HOOK_BEFORE_SAY!='') {
          eval(SETTINGS_HOOK_BEFORE_SAY);
         }
-        if ($level >= (int)getGlobal('minMsgLevel'))
+        if ($level <= (int)getGlobal('minMsgLevel'))
         { 
 
            if (!defined('SETTINGS_SPEAK_SIGNAL') || SETTINGS_SPEAK_SIGNAL=='1') {


### PR DESCRIPTION
Это уровень, НИЖЕ которого сообщения произносятся! Днем стандартная настройка стоит по-умолчанию на 4, ночью - на 2. 
Т.е. заданное для сообщения на 4 должно произноситься днем и не должно ночью! 
А тут получался парадокс: ночью ДИНГДОНГ проигрывался из-за ошибки, но ничего не говорило, т.к. произносил стандартный sayTo, который корректно воспринимал уровни!