### PR TITLE
Режим LIGHT - без строки ввода

### DIFF
--- a/modules/app_chatbox/chat_search.inc.php
+++ b/modules/app_chatbox/chat_search.inc.php
@@ -82,6 +82,10 @@
    $out['MOBILE']=1;
   }
 
+  if ($this->light) {
+   $out['LIGHT']=1;
+  }
+
 if (defined('SETTINGS_GENERAL_ALICE_NAME') && SETTINGS_GENERAL_ALICE_NAME!='') {
  $comp_name=SETTINGS_GENERAL_ALICE_NAME;
 } else {


### PR DESCRIPTION
Отключение строки ввода, если она не нужна, к примеру, в "часах" или на умном зеркале.